### PR TITLE
改进系统生成图像时，CPUGPU和内存的圆环图比例错误问题

### DIFF
--- a/main.py
+++ b/main.py
@@ -427,12 +427,12 @@ class SysInfoImgPlugin(Star):
             
             # 计算进度弧度
             start_angle = -90  # 从顶部开始
-            end_angle = start_angle + (percentage / 100) * 360
+            arc_length = int((percentage / 100) * 360)
             
             # 绘制进度弧（使用多个小弧段来模拟）
             if percentage > 0:
-                for i in range(int(percentage * 3.6)):  # 每度一个点
-                    angle = math.radians(start_angle + i / 3.6)
+                for i in range(arc_length):  # 每度一个点
+                    angle = math.radians(start_angle + i)
                     x1 = center_x + (radius - 4) * math.cos(angle)
                     y1 = center_y + (radius - 4) * math.sin(angle)
                     x2 = center_x + (radius + 4) * math.cos(angle)


### PR DESCRIPTION
以前的插件生成图片圆环图比例错误如下，明显可见比例错误，满负荷才接近1/4，想到可能是算法中 i 多除了个3.6
<img width="900" height="850" alt="d71a133d8527f071b71cb9a2d5d518ba" src="https://github.com/user-attachments/assets/64779cac-eb83-4448-bea4-a93778d184b2" />
改进后生成图片如下，代码逻辑不变，仅仅改了计算公式
<img width="900" height="850" alt="6e8ca9a0b4c4c5fd0300dcf688427fce" src="https://github.com/user-attachments/assets/6bf3fb3e-0b5c-41c5-9a2c-1b6da2d1332a" />
